### PR TITLE
Python3 support and timeout for bluetooth

### DIFF
--- a/spheropy/BluetoothWrapper.py
+++ b/spheropy/BluetoothWrapper.py
@@ -113,7 +113,7 @@ class BluetoothWrapper(object):
         `num_bytes` refers to the number of bytes to read the amount returned may be less
 
         When sphero is disconnected, and all data is read, the empty string is returned.
-        Blocks until at least one byte is available.
+        Blocks until timeout or if timeout is None at least one byte is available.
         """
         if self._socket is None:
             raise BluetoothException("Device is not connected")
@@ -123,9 +123,8 @@ class BluetoothWrapper(object):
                 self.close()
             return data
         except bluetooth.BluetoothError as error:
-            self.close()
             raise BluetoothException(
-                "Unable to receive data due to bluetooth error: " + error.message)
+                "Unable to receive data due to bluetooth error: " + error)
 
     def close(self):
         """
@@ -134,3 +133,6 @@ class BluetoothWrapper(object):
         if self._socket is not None:
             self._socket.close()
             self._socket = None
+
+    def set_timeout(self,timeout):
+        self._socket.settimeout(timeout)

--- a/spheropy/Sphero.py
+++ b/spheropy/Sphero.py
@@ -256,8 +256,10 @@ class Sphero(object):
                     self._handle_async()
                 else:
                     eprint("Malformed Packet")
-            except SpheroException:
-                return
+            except Exception as error:
+                continue
+                #eprint(error)
+                #return
 
     def _handle_acknowledge(self):
         """
@@ -407,6 +409,7 @@ class Sphero(object):
         if not res:
             raise ValueError("Could not connect to device.")
         self._recieve_thread = threading.Thread(target=self._recieve_loop)
+        self.bluetooth.set_timeout(5)
         return res
 
     def disconnect(self):
@@ -414,6 +417,7 @@ class Sphero(object):
         Closes the connection to the sphero.
         If sphero is not connected the call has no effect.
         """
+        # self.bluetooth.set_timeout(5)
         self.bluetooth.close()
 
     def _stable_send(self, did, cid, data, response):


### PR DESCRIPTION
Added Python 3 support (as mention in #1). Therefore the buffer had to be changed. (I wrote a simple implementation that uses the `bytes` function). Also the receive thread blocked Sphero to disconnect due to unlimited wait on a bluetooth signal. So I added a timeout for 5 seconds to receive a signal.